### PR TITLE
Changed HDR handling to use svtav1-params and accompanying values and syntax.

### DIFF
--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -176,8 +176,8 @@ def get_hdr_setings(file_path):
 
     # Set up dictionary mapping for known replacements of ffprobe values to be used by svtav1-params
     color_space_mapping = {
-    'bt2020nc': 'bt2020-ncl',
-    'bt2020c': 'bt2020-cl',
+        'bt2020nc': 'bt2020-ncl',
+        'bt2020c': 'bt2020-cl',
     }
 
     for frame in media_info['frames']:

--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -174,7 +174,7 @@ def get_hdr_setings(file_path):
 
     hdr_settings = {}
 
-    #Set up dictionary mapping for known replacements of ffprobe values to be used by svtav1-params
+    # Set up dictionary mapping for known replacements of ffprobe values to be used by svtav1-params
     color_space_mapping = {
     'bt2020nc': 'bt2020-ncl',
     'bt2020c': 'bt2020-cl',

--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -174,8 +174,14 @@ def get_hdr_setings(file_path):
 
     hdr_settings = {}
 
+    #Set up dictionary mapping for known replacements of ffprobe values to be used by svtav1-params
+    color_space_mapping = {
+    'bt2020nc': 'bt2020-ncl',
+    'bt2020c': 'bt2020-cl',
+    }
+
     for frame in media_info['frames']:
-        hdr_settings['color_space'] = 'bt2020-ncl' if frame['color_space'] == 'bt2020nc' else frame['color_space']
+        hdr_settings['color_space'] = color_space_mapping.get(frame['color_space'], frame['color_space'])
         hdr_settings['color_primaries'] = frame['color_primaries']
         hdr_settings['color_transfer'] = frame['color_transfer']
         hdr_settings['pix_fmt'] = frame['pix_fmt']

--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -175,7 +175,7 @@ def get_hdr_setings(file_path):
     hdr_settings = {}
 
     for frame in media_info['frames']:
-        hdr_settings['color_space'] = frame['color_space']
+        hdr_settings['color_space'] = 'bt2020-ncl' if frame['color_space'] == 'bt2020nc' else frame['color_space']
         hdr_settings['color_primaries'] = frame['color_primaries']
         hdr_settings['color_transfer'] = frame['color_transfer']
         hdr_settings['pix_fmt'] = frame['pix_fmt']
@@ -211,7 +211,7 @@ def run_ffmpeg(input_path, output_path):
 
     if check_hdr(input_path):
         hdr_settings = get_hdr_setings(input_path)
-        encode_settings['libsvtav1-params'] = 'hdr-opt=1:repeat-headers=1:colorprim={color_primaries}:transfer={color_transfer}:colormatrix={color_space}:master-display=R({red_x},{red_y})G({green_x},{green_y})B({blue_x},{blue_y})WP({white_point_x},{white_point_y})L({max_luminance},{min_luminance}):max-cll={max_content},{max_average} -pix_fmt {pix_fmt}'.format(**hdr_settings)  # noqa: E501
+        encode_settings['svtav1-params'] = 'enable-hdr=1:color-primaries={color_primaries}:transfer-characteristics={color_transfer}:matrix-coefficients={color_space}:mastering-display=R({red_x},{red_y})G({green_x},{green_y})B({blue_x},{blue_y})WP({white_point_x},{white_point_y})L({max_luminance},{min_luminance}):content-light={max_content},{max_average} -pix_fmt {pix_fmt}'.format(**hdr_settings)  # noqa: E501
 
     ffmpeg = (
         FFmpeg().input(input_path).output(


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

Current handling of HDR encoding appears to be broken. This is due to the libsvtav1-params command not being recognized by the libsvtav1 encoder in FFmpeg. Reading GitLab documentation suggests using svtav1-params. Documentation: https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/Parameters.md

## Choices

The first change is a find and replace within the run_ffmpeg function. This updates the options in in encode_settings to use svtav1-params and its associated values as replacements for the old libsvtav1-params and its associated values.

get_hdr_settings has also been updated as svtav1-params does not accept the standard ffprobe output in color_spaces but instead requires tweaked values. A dictionary has been added and if a match from the dictionary is found in the color_space variable input it is mapped to an appropriate value; otherwise the dictionary should be ignored.

## Test instructions

1. Using HDR content previously encoded with perform encode.
2. Run ffproble check (ffprobe -hide_banner -loglevel warning -select_streams v -print_format json -show_frames -read_intervals "%+#1" -show_entries "frame=color_space,color_primaries,color_transfer,side_data_list,pix_fmt" -i [File.mkv]) against original file, newly encoded file, and previously encoded file.
3. Verify outputs to ensure that all files match indicating an identical encode.

Note: Some mastering display settings may not be identical as input values are typically simplified rather than having the same input values as pulled from ffprobe. In this case calculated values should still match (e.g. "red_x": "34000/50000" = 0.68 = "red_x": "34000/50000").

## Checklist before requesting a review

* [X] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [X] I've not introduced breaking changes.
