### PR TITLE
Update HDR check and readd header information with each keyframe.

### DIFF
--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -176,8 +176,8 @@ def get_hdr_setings(file_path):
 
     # Set up dictionary mapping for known replacements of ffprobe values to be used by svtav1-params
     color_space_mapping = {
-    'bt2020nc': 'bt2020-ncl',
-    'bt2020c': 'bt2020-cl',
+        'bt2020nc': 'bt2020-ncl',
+        'bt2020c': 'bt2020-cl',
     }
 
     for frame in media_info['frames']:

--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -174,7 +174,7 @@ def get_hdr_setings(file_path):
 
     hdr_settings = {}
 
-    #Set up dictionary mapping for known replacements of ffprobe values to be used by svtav1-params
+    # Set up dictionary mapping for known replacements of ffprobe values to be used by svtav1-params
     color_space_mapping = {
     'bt2020nc': 'bt2020-ncl',
     'bt2020c': 'bt2020-cl',

--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -174,8 +174,14 @@ def get_hdr_setings(file_path):
 
     hdr_settings = {}
 
+    #Set up dictionary mapping for known replacements of ffprobe values to be used by svtav1-params
+    color_space_mapping = {
+    'bt2020nc': 'bt2020-ncl',
+    'bt2020c': 'bt2020-cl',
+    }
+
     for frame in media_info['frames']:
-        hdr_settings['color_space'] = 'bt2020-ncl' if frame['color_space'] == 'bt2020nc' else frame['color_space']
+        hdr_settings['color_space'] = color_space_mapping.get(frame['color_space'], frame['color_space'])
         hdr_settings['color_primaries'] = frame['color_primaries']
         hdr_settings['color_transfer'] = frame['color_transfer']
         hdr_settings['pix_fmt'] = frame['pix_fmt']

--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -175,7 +175,7 @@ def get_hdr_setings(file_path):
     hdr_settings = {}
 
     for frame in media_info['frames']:
-        hdr_settings['color_space'] = frame['color_space']
+        hdr_settings['color_space'] = 'bt2020-ncl' if frame['color_space'] == 'bt2020nc' else frame['color_space']
         hdr_settings['color_primaries'] = frame['color_primaries']
         hdr_settings['color_transfer'] = frame['color_transfer']
         hdr_settings['pix_fmt'] = frame['pix_fmt']
@@ -211,7 +211,7 @@ def run_ffmpeg(input_path, output_path):
 
     if check_hdr(input_path):
         hdr_settings = get_hdr_setings(input_path)
-        encode_settings['libsvtav1-params'] = 'hdr-opt=1:repeat-headers=1:colorprim={color_primaries}:transfer={color_transfer}:colormatrix={color_space}:master-display=R({red_x},{red_y})G({green_x},{green_y})B({blue_x},{blue_y})WP({white_point_x},{white_point_y})L({max_luminance},{min_luminance}):max-cll={max_content},{max_average} -pix_fmt {pix_fmt}'.format(**hdr_settings)  # noqa: E501
+        encode_settings['svtav1-params'] = 'enable-hdr=1:color-primaries={color_primaries}:transfer-characteristics={color_transfer}:matrix-coefficients={color_space}:mastering-display=R({red_x},{red_y})G({green_x},{green_y})B({blue_x},{blue_y})WP({white_point_x},{white_point_y})L({max_luminance},{min_luminance}):content-light={max_content},{max_average} -pix_fmt {pix_fmt}'.format(**hdr_settings)  # noqa: E501
 
     ffmpeg = (
         FFmpeg().input(input_path).output(

--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -154,8 +154,7 @@ def check_hdr(file_path):
     for stream in media_info['streams']:
         if stream['codec_type'] == 'video':
             if 'color_space' in stream:
-                if 'color_space' in stream and 'bt2020' in stream['color_space']:
-                    hdr = True
+                hdr = 'bt2020' in stream.get('color_space')
             break
 
     return hdr

--- a/scripts/ffmpeg_automator.py
+++ b/scripts/ffmpeg_automator.py
@@ -154,7 +154,8 @@ def check_hdr(file_path):
     for stream in media_info['streams']:
         if stream['codec_type'] == 'video':
             if 'color_space' in stream:
-                hdr = stream.get('color_space') == 'bt2020nc'
+                if 'color_space' in stream and 'bt2020' in stream['color_space']:
+                    hdr = True
             break
 
     return hdr
@@ -217,7 +218,7 @@ def run_ffmpeg(input_path, output_path):
 
     if check_hdr(input_path):
         hdr_settings = get_hdr_setings(input_path)
-        encode_settings['svtav1-params'] = 'enable-hdr=1:color-primaries={color_primaries}:transfer-characteristics={color_transfer}:matrix-coefficients={color_space}:mastering-display=R({red_x},{red_y})G({green_x},{green_y})B({blue_x},{blue_y})WP({white_point_x},{white_point_y})L({max_luminance},{min_luminance}):content-light={max_content},{max_average} -pix_fmt {pix_fmt}'.format(**hdr_settings)  # noqa: E501
+        encode_settings['svtav1-params'] = 'enable-hdr=1:repetition_headers=1:color-primaries={color_primaries}:transfer-characteristics={color_transfer}:matrix-coefficients={color_space}:mastering-display=R({red_x},{red_y})G({green_x},{green_y})B({blue_x},{blue_y})WP({white_point_x},{white_point_y})L({max_luminance},{min_luminance}):content-light={max_content},{max_average} -pix_fmt {pix_fmt}'.format(**hdr_settings)  # noqa: E501
 
     ffmpeg = (
         FFmpeg().input(input_path).output(


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

Readding header information with each keyframe and updating the HDR check to be a little more generic.

## Choices

The HDR check is meant to include any color_space containing 'bt2020' as there are multiple versions of color space (bt2020nc and bt2020c and both are HDR color spaces. Not being very good with python I added a double check for the color_space variable.

Adding the additional parameter of "repetition_headers=1" is just a hardcoded variable added to svtav1-params.

## Test instructions

1. Reencoded an HDR file previously encoded.
2. Checked output against previous output to ensure that file is correctly output.

## Checklist before requesting a review

* [X] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [X] I've not introduced breaking changes.
